### PR TITLE
fixed relative url to http url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Now that there has been a release (2.0.0) time to start a change log to help
 understand what is going on.
 
-Trying to follow the suggestions at [Keep a Change Log](keepachangelog.com) and [Semantic Versioning] (http://semver.org/spec/v2.0.0.html)
+Trying to follow the suggestions at [Keep a Change Log](http://keepachangelog.com) and [Semantic Versioning] (http://semver.org/spec/v2.0.0.html)
 
 ##[2.0.1]
 ### Added


### PR DESCRIPTION
Github markdown treated the url without the http prefix as a relative link. Added the http prefix.
