### PR TITLE
Fix Simple loading of DeletedObjects section

### DIFF
--- a/simple/src/main/java/org/linguafranca/pwdb/kdbx/simple/model/KeePassFile.java
+++ b/simple/src/main/java/org/linguafranca/pwdb/kdbx/simple/model/KeePassFile.java
@@ -51,8 +51,8 @@ public class KeePassFile {
     public static class Root {
         @Element(name = "Group")
         public SimpleGroup group;
-        @ElementList(name = "DeletedObjects", required = false, type=ArrayList.class)
-        protected ArrayList<KeePassFile.Binaries.Binary> deletedObjects;
+        @ElementList(name = "DeletedObjects", required = false)
+        protected ArrayList<DeletedObject> deletedObjects;
 
         public SimpleGroup getGroup() {
             return group;
@@ -239,5 +239,15 @@ public class KeePassFile {
 
     public static class CustomData {
         protected List<Object> any;
+    }
+
+    @org.simpleframework.xml.Root(name = "DeletedObject")
+    public static class DeletedObject {
+        @Element(name = "UUID", type = UUID.class)
+        @Convert(UuidConverter.class)
+        protected UUID uuid;
+        @Element(name = "DeletionTime", type = Date.class)
+        @Convert(TimeConverter.class)
+        protected Date deletionTime;
     }
 }


### PR DESCRIPTION
Simple was failing to parse my kdbx file. I tracked this down to the DeletedObjects section, which was expecting a list of binaries. Here's a snippet of my actual DeletedObjects:

```
		<DeletedObjects>
			<DeletedObject>
				<UUID>dOnwUNeOqkG6z9UUvx0Vlg==</UUID>
				<DeletionTime>2016-12-16T00:08:30Z</DeletionTime>
			</DeletedObject>
```