### PR TITLE
Detect existing Recycle Bin group if it wasn't specified in Meta

### DIFF
--- a/database/src/main/java/org/linguafranca/pwdb/base/AbstractDatabase.java
+++ b/database/src/main/java/org/linguafranca/pwdb/base/AbstractDatabase.java
@@ -29,6 +29,8 @@ import java.util.UUID;
  */
 public abstract class AbstractDatabase<D extends Database<D, G, E, I>, G extends Group<D, G, E, I>, E extends Entry<D,G,E,I>, I extends Icon> implements Database<D, G, E, I> {
 
+    protected static final String RECYCLE_BIN_NAME = "Recycle Bin";
+
     private boolean isDirty;
 
     @Override
@@ -223,6 +225,11 @@ public abstract class AbstractDatabase<D extends Database<D, G, E, I>, G extends
         for (E e: recycle.getEntries()){
             recycle.removeEntry(e);
         }
+    }
+
+    protected G findRecycleBinCandidate() {
+        List<? extends G> candidates = getRootGroup().findGroups(RECYCLE_BIN_NAME);
+        return candidates.size() > 0 ? candidates.get(0) : null;
     }
 
     @Override

--- a/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomDatabaseWrapper.java
+++ b/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomDatabaseWrapper.java
@@ -141,9 +141,12 @@ public class DomDatabaseWrapper extends AbstractDatabase<DomDatabaseWrapper, Dom
             return null;
         }
 
-        DomGroupWrapper g = newGroup();
-        g.setName("Recycle Bin");
-        getRootGroup().addGroup(g);
+        DomGroupWrapper g = findRecycleBinCandidate();
+        if (g == null) {
+            g = newGroup(RECYCLE_BIN_NAME);
+            getRootGroup().addGroup(g);
+        }
+
         ensureElementContent(RECYCLE_BIN_UUID_ELEMENT_NAME, dbMeta, base64FromUuid(g.getUuid()));
         touchElement(RECYCLE_BIN_CHANGED_ELEMENT_NAME, dbMeta);
         return g;

--- a/jaxb/src/main/java/org/linguafranca/pwdb/kdbx/jaxb/JaxbDatabase.java
+++ b/jaxb/src/main/java/org/linguafranca/pwdb/kdbx/jaxb/JaxbDatabase.java
@@ -101,8 +101,11 @@ public class JaxbDatabase extends AbstractDatabase<JaxbDatabase, JaxbGroup, Jaxb
             return null;
         }
         if (g == null) {
-            g = newGroup("Recycle Bin");
-            getRootGroup().addGroup(g);
+            g = findRecycleBinCandidate();
+            if (g == null) {
+                g = newGroup("Recycle Bin");
+                getRootGroup().addGroup(g);
+            }
             this.keePassFile.getMeta().setRecycleBinUUID(g.getUuid());
             this.keePassFile.getMeta().setRecycleBinChanged(new Date());
         }

--- a/simple/src/main/java/org/linguafranca/pwdb/kdbx/simple/SimpleDatabase.java
+++ b/simple/src/main/java/org/linguafranca/pwdb/kdbx/simple/SimpleDatabase.java
@@ -115,8 +115,11 @@ public class SimpleDatabase extends AbstractDatabase<SimpleDatabase, SimpleGroup
         UUID recycleBinUuid = this.keePassFile.meta.recycleBinUUID;
         SimpleGroup g = findGroup(recycleBinUuid);
         if (g == null && isRecycleBinEnabled()) {
-            g = newGroup("Recycle Bin");
-            getRootGroup().addGroup(g);
+            g = findRecycleBinCandidate();
+            if (g == null) {
+                g = newGroup(RECYCLE_BIN_NAME);
+                getRootGroup().addGroup(g);
+            }
             this.keePassFile.meta.recycleBinUUID = g.getUuid();
             this.keePassFile.meta.recycleBinChanged = new Date();
         }

--- a/test/src/main/java/org/linguafranca/pwdb/checks/RecycleBinChecks.java
+++ b/test/src/main/java/org/linguafranca/pwdb/checks/RecycleBinChecks.java
@@ -76,4 +76,20 @@ public abstract class RecycleBinChecks  <D extends Database<D,G,E,I>, G extends 
         assertEquals(0, recycleBin.getGroupsCount());
     }
 
+    @Test
+    public void recycleBinSelectedByName() {
+        database.enableRecycleBin(true);
+        assertTrue(database.isRecycleBinEnabled());
+
+        // Add group with "Recycle Bin" name
+        G recycleBinCandidate = database.newGroup("Recycle Bin");
+        database.getRootGroup().addGroup(recycleBinCandidate);
+        assertEquals(1, database.getRootGroup().getGroups().size());
+
+        // Check that "Recycle Bin" was selected by its name
+        G recycleBin = database.getRecycleBin();
+        assertNotNull(recycleBin);
+        assertEquals(recycleBinCandidate.getUuid(), recycleBin.getUuid());
+    }
+
 }


### PR DESCRIPTION
Some KeePass clients may create "Recycle Bin" but don't specify it in database metadata.
In order to not create an excessive "Recycle Bin" group, it can be detected by name. If a group with the name "Recycle Bin" wasn't found, then create a new one.