### PR TITLE
Support for Java 11 & other changes

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -24,9 +24,9 @@
             <version>31.1-jre</version>
         </dependency>
         <dependency>
-            <groupId>com.madgag.spongycastle</groupId>
-            <artifactId>core</artifactId>
-            <version>1.58.0.0</version>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>com.kosprov.jargon2</groupId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -39,5 +39,11 @@
             <version>1.1.1</version>
             <scope>runtime</scope>
         </dependency>
+        <!--Since javax.annotation has been removed since Java 11, this adds it as a dependency-->
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.7.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
+            <version>31.1-android</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -16,24 +16,27 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
+            <version>23.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.madgag.spongycastle</groupId>
             <artifactId>core</artifactId>
+            <version>1.58.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.kosprov.jargon2</groupId>
             <artifactId>jargon2-api</artifactId>
-            <version>1.0.1</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.kosprov.jargon2</groupId>
             <artifactId>jargon2-native-ri-backend</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/database/src/main/java/org/linguafranca/pwdb/Entry.java
+++ b/database/src/main/java/org/linguafranca/pwdb/Entry.java
@@ -103,12 +103,12 @@ public interface Entry <D extends Database<D, G, E, I>, G extends Group<D, G, E,
      * @return a value or null if the property is not known, or if setting of arbitrary properties is not supported
      * @see Database#supportsNonStandardPropertyNames()
      */
-    String getProperty(String name);
+    char[] getProperty(String name);
 
     /**
      * Sets the value of a property.
      *
-     * <p>Other than the {@link #STANDARD_PROPERTY_NAMES} support for this methd is optional.
+     * <p>Other than the {@link #STANDARD_PROPERTY_NAMES} support for this method is optional.
      *
      * @param name the name of the property to set
      * @param value the value to set it to
@@ -200,7 +200,7 @@ public interface Entry <D extends Database<D, G, E, I>, G extends Group<D, G, E,
      * Get the username field of this entry
      * @return a username
      */
-    String getUsername();
+    char[] getUsername();
 
     /**
      * set the username
@@ -222,7 +222,7 @@ public interface Entry <D extends Database<D, G, E, I>, G extends Group<D, G, E,
      *
      * @return a password
      */
-    String getPassword();
+    char[] getPassword();
 
     /**
      * Sets the plaintext password for this Entry.
@@ -240,7 +240,7 @@ public interface Entry <D extends Database<D, G, E, I>, G extends Group<D, G, E,
      *
      * @return a string representation of a URL
      */
-    String getUrl();
+    char[] getUrl();
 
     /**
      * Sets the url for this Entry.
@@ -265,7 +265,7 @@ public interface Entry <D extends Database<D, G, E, I>, G extends Group<D, G, E,
      *
      * @return a title
      */
-    String getTitle();
+    char[] getTitle();
 
     /**
      * Sets the title for this Entry.
@@ -290,7 +290,7 @@ public interface Entry <D extends Database<D, G, E, I>, G extends Group<D, G, E,
      *
      * @return the notes field
      */
-    String getNotes();
+    char[] getNotes();
 
     /**
      * Sets the notes for this Entry.

--- a/database/src/main/java/org/linguafranca/pwdb/base/AbstractDatabase.java
+++ b/database/src/main/java/org/linguafranca/pwdb/base/AbstractDatabase.java
@@ -107,7 +107,7 @@ public abstract class AbstractDatabase<D extends Database<D, G, E, I>, G extends
         for (String propertyName: entry.getPropertyNames()) {
             try {
                 // all implementations must support setting of STANDARD_PROPERTY_NAMES
-                result.setProperty(propertyName, entry.getProperty(propertyName));
+                result.setProperty(propertyName, String.valueOf(entry.getProperty(propertyName)));
             } catch (UnsupportedOperationException e) {
                 // oh well, we tried
             }

--- a/database/src/main/java/org/linguafranca/pwdb/base/AbstractEntry.java
+++ b/database/src/main/java/org/linguafranca/pwdb/base/AbstractEntry.java
@@ -30,22 +30,22 @@ public abstract class AbstractEntry<D extends Database<D, G, E, I>, G extends Gr
 
     @Override
     public  boolean matchTitle(String text){
-        return (getTitle() != null && getTitle().toLowerCase().contains(text.toLowerCase()));
+        return (getTitle() != null && String.valueOf(getTitle()).toLowerCase().contains(text.toLowerCase()));
     }
 
     @Override
     public  boolean matchNotes(String text){
-        return (getNotes()!=null && getNotes().toLowerCase().contains(text.toLowerCase()));
+        return (getNotes()!= null && String.valueOf(getNotes()).toLowerCase().contains(text.toLowerCase()));
     }
 
     @Override
     public  boolean matchUsername(String text){
-        return (getUsername()!=null && getUsername().toLowerCase().contains(text.toLowerCase()));
+        return (getUsername()!= null && String.valueOf(getUsername()).toLowerCase().contains(text.toLowerCase()));
     }
 
     @Override
     public  boolean matchUrl(String text){
-        return (getUrl()!=null && getUrl().toLowerCase().contains(text.toLowerCase()));
+        return (getUrl()!= null && String.valueOf(getUrl()).toLowerCase().contains(text.toLowerCase()));
     }
 
     @Override
@@ -73,7 +73,7 @@ public abstract class AbstractEntry<D extends Database<D, G, E, I>, G extends Gr
     }
 
     @Override
-    public String getUsername() {
+    public char[] getUsername() {
         return getProperty(STANDARD_PROPERTY_NAME_USER_NAME);
     }
 
@@ -84,7 +84,7 @@ public abstract class AbstractEntry<D extends Database<D, G, E, I>, G extends Gr
     }
 
     @Override
-    public String getPassword() {
+    public char[] getPassword() {
         return getProperty(STANDARD_PROPERTY_NAME_PASSWORD);
     }
 
@@ -95,7 +95,7 @@ public abstract class AbstractEntry<D extends Database<D, G, E, I>, G extends Gr
     }
 
     @Override
-    public String getUrl() {
+    public char[] getUrl() {
         return getProperty(STANDARD_PROPERTY_NAME_URL);
     }
 
@@ -106,7 +106,7 @@ public abstract class AbstractEntry<D extends Database<D, G, E, I>, G extends Gr
     }
 
     @Override
-    public String getTitle() {
+    public char[] getTitle() {
         return getProperty(STANDARD_PROPERTY_NAME_TITLE);
     }
 
@@ -117,7 +117,7 @@ public abstract class AbstractEntry<D extends Database<D, G, E, I>, G extends Gr
     }
 
     @Override
-    public String getNotes() {
+    public char[] getNotes() {
         return getProperty(STANDARD_PROPERTY_NAME_NOTES);
     }
 

--- a/database/src/main/java/org/linguafranca/pwdb/security/Aes.java
+++ b/database/src/main/java/org/linguafranca/pwdb/security/Aes.java
@@ -1,12 +1,12 @@
 package org.linguafranca.pwdb.security;
 
-import org.spongycastle.crypto.engines.AESEngine;
-import org.spongycastle.crypto.io.CipherInputStream;
-import org.spongycastle.crypto.io.CipherOutputStream;
-import org.spongycastle.crypto.modes.CBCBlockCipher;
-import org.spongycastle.crypto.paddings.PaddedBufferedBlockCipher;
-import org.spongycastle.crypto.params.KeyParameter;
-import org.spongycastle.crypto.params.ParametersWithIV;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.io.CipherInputStream;
+import org.bouncycastle.crypto.io.CipherOutputStream;
+import org.bouncycastle.crypto.modes.CBCBlockCipher;
+import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
 
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/database/src/main/java/org/linguafranca/pwdb/security/Aes.java
+++ b/database/src/main/java/org/linguafranca/pwdb/security/Aes.java
@@ -30,7 +30,7 @@ public class Aes implements CipherAlgorithm, KeyDerivationFunction {
     private static VariantDictionary kdfParameters = new VariantDictionary((short) 1);
     static {
         kdfParameters.putUuid("$UUID", KDF);
-        kdfParameters.putLong(ParamRounds, 6000L);
+        kdfParameters.putLong(ParamRounds, 60000L);
         kdfParameters.putByteArray(ParamSeed, SecureRandom.getSeed(32));
     }
 

--- a/database/src/main/java/org/linguafranca/pwdb/security/ChaCha.java
+++ b/database/src/main/java/org/linguafranca/pwdb/security/ChaCha.java
@@ -1,11 +1,11 @@
 package org.linguafranca.pwdb.security;
 
-import org.spongycastle.crypto.StreamCipher;
-import org.spongycastle.crypto.engines.ChaCha7539Engine;
-import org.spongycastle.crypto.io.CipherInputStream;
-import org.spongycastle.crypto.io.CipherOutputStream;
-import org.spongycastle.crypto.params.KeyParameter;
-import org.spongycastle.crypto.params.ParametersWithIV;
+import org.bouncycastle.crypto.StreamCipher;
+import org.bouncycastle.crypto.engines.ChaCha7539Engine;
+import org.bouncycastle.crypto.io.CipherInputStream;
+import org.bouncycastle.crypto.io.CipherOutputStream;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
 
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomDatabaseWrapper.java
+++ b/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomDatabaseWrapper.java
@@ -123,7 +123,7 @@ public class DomDatabaseWrapper extends AbstractDatabase<DomDatabaseWrapper, Dom
 
     @Override
     public DomGroupWrapper getRecycleBin() {
-        String UUIDcontent = getElementContent(RECYCLE_BIN_UUID_ELEMENT_NAME, dbMeta);
+        String UUIDcontent = String.valueOf(getElementContent(RECYCLE_BIN_UUID_ELEMENT_NAME, dbMeta));
         if (UUIDcontent != null){
             final UUID uuid = Helpers.uuidFromBase64(UUIDcontent);
             if (uuid.getLeastSignificantBits() != 0 && uuid.getMostSignificantBits() != 0) {
@@ -151,7 +151,7 @@ public class DomDatabaseWrapper extends AbstractDatabase<DomDatabaseWrapper, Dom
 
     @Override
     public boolean isRecycleBinEnabled() {
-        return Boolean.valueOf(getElementContent(RECYCLE_BIN_ENABLED_ELEMENT_NAME, dbMeta));
+        return Boolean.valueOf(String.valueOf(getElementContent(RECYCLE_BIN_ENABLED_ELEMENT_NAME, dbMeta)));
     }
 
     @Override
@@ -159,8 +159,8 @@ public class DomDatabaseWrapper extends AbstractDatabase<DomDatabaseWrapper, Dom
         setElementContent(RECYCLE_BIN_ENABLED_ELEMENT_NAME, dbMeta, ((Boolean) enable).toString());
     }
 
-    public String getName() {
-        return DomHelper.getElementContent("DatabaseName", dbMeta);
+    public String getName() {    	
+        return String.valueOf(DomHelper.getElementContent("DatabaseName", dbMeta));
     }
 
     public void setName(String name) {
@@ -170,8 +170,8 @@ public class DomDatabaseWrapper extends AbstractDatabase<DomDatabaseWrapper, Dom
     }
 
     @Override
-    public String getDescription() {
-        return DomHelper.getElementContent("DatabaseDescription", dbMeta);
+    public String getDescription() {	
+        return String.valueOf(DomHelper.getElementContent("DatabaseDescription", dbMeta));
     }
 
     @Override

--- a/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomEntryWrapper.java
+++ b/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomEntryWrapper.java
@@ -59,7 +59,7 @@ public class DomEntryWrapper extends AbstractEntry <DomDatabaseWrapper, DomGroup
     }
 
     @Override
-    public String getProperty(String name) {
+    public char[] getProperty(String name) {
         Element property = DomHelper.getElement(String.format(DomHelper.PROPERTY_ELEMENT_FORMAT, name), element, false);
         if (property == null) {
             return null;
@@ -92,7 +92,7 @@ public class DomEntryWrapper extends AbstractEntry <DomDatabaseWrapper, DomGroup
         ArrayList<String> result = new ArrayList<>();
         List<Element> list = DomHelper.getElements("String", element);
         for (Element listElement: list) {
-            result.add(DomHelper.getElementContent("Key", listElement));
+            result.add(String.valueOf(DomHelper.getElementContent("Key", listElement)));
         }
         return result;
     }
@@ -131,7 +131,7 @@ public class DomEntryWrapper extends AbstractEntry <DomDatabaseWrapper, DomGroup
         ArrayList<String> result = new ArrayList<>();
         List<Element> list = DomHelper.getElements("Binary", element);
         for (Element listElement: list) {
-            result.add(DomHelper.getElementContent("Key", listElement));
+        	result.add(String.valueOf(DomHelper.getElementContent("Key", listElement)));
         }
         return result;
     }
@@ -152,10 +152,10 @@ public class DomEntryWrapper extends AbstractEntry <DomDatabaseWrapper, DomGroup
         }
         return new DomGroupWrapper((Element) element.getParentNode(), database, false);
     }
-
+    
     @Override
     public UUID getUuid() {
-        return Helpers.uuidFromBase64(DomHelper.getElementContent(DomHelper.UUID_ELEMENT_NAME, element));
+        return Helpers.uuidFromBase64(String.valueOf(DomHelper.getElementContent(DomHelper.UUID_ELEMENT_NAME, element)));
     }
 
     @Override
@@ -172,17 +172,17 @@ public class DomEntryWrapper extends AbstractEntry <DomDatabaseWrapper, DomGroup
 
     @Override
     public Date getLastAccessTime() {
-        return Helpers.toDate(DomHelper.getElementContent(DomHelper.LAST_ACCESS_TIME_ELEMENT_NAME, element));
+        return Helpers.toDate(String.valueOf(DomHelper.getElementContent(DomHelper.LAST_ACCESS_TIME_ELEMENT_NAME, element)));
     }
 
     @Override
     public Date getCreationTime() {
-        return Helpers.toDate(DomHelper.getElementContent(DomHelper.CREATION_TIME_ELEMENT_NAME, element));
+        return Helpers.toDate(String.valueOf(DomHelper.getElementContent(DomHelper.CREATION_TIME_ELEMENT_NAME, element)));
     }
 
     @Override
     public boolean getExpires() {
-        String content = DomHelper.getElementContent(DomHelper.EXPIRES_ELEMENT_NAME, element);
+        String content = String.valueOf(DomHelper.getElementContent(DomHelper.EXPIRES_ELEMENT_NAME, element));
         return content != null && content.equalsIgnoreCase("true");
     }
 
@@ -192,8 +192,8 @@ public class DomEntryWrapper extends AbstractEntry <DomDatabaseWrapper, DomGroup
     }
 
     @Override
-    public Date getExpiryTime() {
-        return Helpers.toDate(DomHelper.getElementContent(DomHelper.EXPIRY_TIME_ELEMENT_NAME, element));
+    public Date getExpiryTime() {    	
+        return Helpers.toDate(String.valueOf(DomHelper.getElementContent(DomHelper.EXPIRY_TIME_ELEMENT_NAME, element)));
     }
 
     @Override
@@ -205,7 +205,7 @@ public class DomEntryWrapper extends AbstractEntry <DomDatabaseWrapper, DomGroup
 
     @Override
     public Date getLastModificationTime() {
-        return Helpers.toDate(DomHelper.getElementContent(DomHelper.LAST_MODIFICATION_TIME_ELEMENT_NAME, element));
+        return Helpers.toDate(String.valueOf(DomHelper.getElementContent(DomHelper.LAST_MODIFICATION_TIME_ELEMENT_NAME, element)));
     }
 
     @Override

--- a/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomGroupWrapper.java
+++ b/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomGroupWrapper.java
@@ -70,7 +70,7 @@ public class DomGroupWrapper extends AbstractGroup<DomDatabaseWrapper, DomGroupW
 
     @Override
     public boolean isRecycleBin() {
-        String UUIDcontent = getElementContent(RECYCLE_BIN_UUID_ELEMENT_NAME, database.dbMeta);
+        String UUIDcontent = String.valueOf(getElementContent(RECYCLE_BIN_UUID_ELEMENT_NAME, database.dbMeta));
         if (UUIDcontent != null){
             UUID uuid = Helpers.uuidFromBase64(UUIDcontent);
             return uuid.equals(this.getUuid());
@@ -169,7 +169,7 @@ public class DomGroupWrapper extends AbstractGroup<DomDatabaseWrapper, DomGroupW
 
     @Override
     public String getName() {
-        return getElementContent(NAME_ELEMENT_NAME, element);
+        return String.valueOf(getElementContent(NAME_ELEMENT_NAME, element));
     }
 
     @Override
@@ -180,7 +180,7 @@ public class DomGroupWrapper extends AbstractGroup<DomDatabaseWrapper, DomGroupW
 
     @Override
     public UUID getUuid() {
-        String encodedUuid = getElementContent(UUID_ELEMENT_NAME, element);
+        String encodedUuid = String.valueOf(getElementContent(UUID_ELEMENT_NAME, element));
         return Helpers.uuidFromBase64(encodedUuid);
     }
 

--- a/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomHelper.java
+++ b/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomHelper.java
@@ -41,7 +41,7 @@ class DomHelper {
 
     static XPath xpath = XPathFactory.newInstance().newXPath();
 
-//    static SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
+    //static SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
 
     static final String GROUP_ELEMENT_NAME = "Group";
     static final String ENTRY_ELEMENT_NAME = "Entry";
@@ -160,9 +160,9 @@ class DomHelper {
     }
 
     @Nullable
-    static String getElementContent(String elementPath, Element parentElement) {
+    static char[] getElementContent(String elementPath, Element parentElement) {
         Element result = getElement(elementPath, parentElement, false);
-        return (result == null) ? null : result.getTextContent();
+        return (result == null) ? null : result.getTextContent().toCharArray();
     }
 
     @NotNull

--- a/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomSerializableDatabase.java
+++ b/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomSerializableDatabase.java
@@ -16,7 +16,6 @@
 
 package org.linguafranca.pwdb.kdbx.dom;
 
-
 import org.linguafranca.pwdb.kdbx.Helpers;
 import org.linguafranca.pwdb.kdbx.SerializableDatabase;
 import org.linguafranca.pwdb.kdbx.StreamEncryptor;
@@ -35,6 +34,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -93,7 +93,7 @@ public class DomSerializableDatabase implements SerializableDatabase {
             NodeList protectedContent = (NodeList) DomHelper.xpath.evaluate("//*[@Protected='True']", doc, XPathConstants.NODESET);
             for (int i = 0; i < protectedContent.getLength(); i++){
                 Element element = ((Element) protectedContent.item(i));
-                String base64 = DomHelper.getElementContent(".", element);
+                String base64 = String.valueOf(DomHelper.getElementContent(".", element));
                 // Android compatibility
                 byte[] encrypted = Base64.decodeBase64(base64.getBytes());
                 String decrypted = new String(encryption.decrypt(encrypted), "UTF-8");
@@ -158,8 +158,8 @@ public class DomSerializableDatabase implements SerializableDatabase {
             // encrypt and base64 every element marked as protected
             NodeList protectedContent = (NodeList) DomHelper.xpath.evaluate("//*[@Protected='True']", copyDoc, XPathConstants.NODESET);
             for (int i = 0; i < protectedContent.getLength(); i++){
-                Element element = ((Element) protectedContent.item(i));
-                String decrypted = DomHelper.getElementContent(".", element);
+                Element element = ((Element) protectedContent.item(i));  
+                String decrypted = String.valueOf(DomHelper.getElementContent(".", element));
                 if (decrypted == null) {
                     decrypted = "";
                 }

--- a/kdb/pom.xml
+++ b/kdb/pom.xml
@@ -21,6 +21,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
+            <version>23.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.linguafranca.pwdb</groupId>

--- a/kdb/src/main/java/org/linguafranca/pwdb/kdb/KdbCredentials.java
+++ b/kdb/src/main/java/org/linguafranca/pwdb/kdb/KdbCredentials.java
@@ -19,7 +19,7 @@ package org.linguafranca.pwdb.kdb;
 import com.google.common.io.ByteStreams;
 import org.linguafranca.pwdb.Credentials;
 import org.linguafranca.pwdb.security.Encryption;
-import org.spongycastle.util.encoders.Hex;
+import org.bouncycastle.util.encoders.Hex;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/kdb/src/main/java/org/linguafranca/pwdb/kdb/KdbEntry.java
+++ b/kdb/src/main/java/org/linguafranca/pwdb/kdb/KdbEntry.java
@@ -35,12 +35,12 @@ import java.util.UUID;
 public class KdbEntry extends AbstractEntry<KdbDatabase, KdbGroup, KdbEntry, KdbIcon> {
     KdbGroup parent;
     private UUID uuid = UUID.randomUUID();
-    private String title = "";
-    private String url = "";
-    private String notes = "";
+    private char[] title;
+    private char[] url;
+    private char[] notes;
     private KdbIcon icon = new KdbIcon(0);
-    private String username = "";
-    private String password = "";
+    private char[] username;
+    private char[] password;
     private Date creationTime = new Date((System.currentTimeMillis()/1000L)*1000L); // to the next lower second
     private Date lastModificationTime = creationTime;
     private Date lastAccessTime = creationTime;
@@ -50,7 +50,7 @@ public class KdbEntry extends AbstractEntry<KdbDatabase, KdbGroup, KdbEntry, Kdb
     private byte[] binaryData = new byte[0];
 
     @Override
-    public String getProperty(String name) {
+    public char[] getProperty(String name) {
         switch (name) {
             case STANDARD_PROPERTY_NAME_USER_NAME: return getUsername();
             case STANDARD_PROPERTY_NAME_PASSWORD: return getPassword();
@@ -103,53 +103,53 @@ public class KdbEntry extends AbstractEntry<KdbDatabase, KdbGroup, KdbEntry, Kdb
     }
 
     @Override
-    public String getUsername() {
+    public char[] getUsername() {
         return username;
     }
 
     @Override
     public void setUsername(String username) {
-        this.username = username;
+        this.username = username.toCharArray();
     }
 
     @Override
-    public String getPassword() {
+    public char[] getPassword() {
         return password;
     }
 
     @Override
     public void setPassword(String pass) {
-        this.password = pass;
+        this.password = pass.toCharArray();
     }
 
     @Override
-    public String getUrl() {
+    public char[] getUrl() {
         return url;
     }
 
     @Override
     public void setUrl(String url) {
-        this.url = url;
+        this.url = url.toCharArray();
     }
 
     @Override
-    public String getTitle() {
+    public char[] getTitle() {
         return title;
     }
 
     @Override
     public void setTitle(String title) {
-        this.title = title;
+        this.title = title.toCharArray();
     }
 
     @Override
-    public String getNotes() {
+    public char[] getNotes() {
         return notes;
     }
 
     @Override
     public void setNotes(String notes) {
-        this.notes = notes;
+        this.notes = notes.toCharArray();
     }
 
     @Override
@@ -213,7 +213,7 @@ public class KdbEntry extends AbstractEntry<KdbDatabase, KdbGroup, KdbEntry, Kdb
 
     public String toString() {
         String time = KdbDatabase.isoDateFormat.format(creationTime);
-        return getPath() + String.format(" (%s, %s, %s) %s [%s]", url, username, notes.substring(0,Math.min(notes.length(), 24)), time, binaryDescription);
+        return getPath() + String.format(" (%s, %s, %s) %s [%s]", String.valueOf(url), String.valueOf(username), String.valueOf(notes).substring(0,Math.min(String.valueOf(notes).length(), 24)), time, binaryDescription);
     }
 
     @Override

--- a/kdbx/pom.xml
+++ b/kdbx/pom.xml
@@ -41,10 +41,12 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
+            <version>23.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.linguafranca.pwdb</groupId>
@@ -55,6 +57,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kdbx/src/main/java/org/linguafranca/pwdb/kdbx/KdbxHeader.java
+++ b/kdbx/src/main/java/org/linguafranca/pwdb/kdbx/KdbxHeader.java
@@ -136,7 +136,7 @@ public class KdbxHeader {
         compressionFlags = CompressionFlags.GZIP;
         masterSeed = random.generateSeed(32);
         transformSeed = random.generateSeed(32);
-        transformRounds = 6000;
+        transformRounds = 60000;
         encryptionIv = random.generateSeed(16);
         innerRandomStreamKey = random.generateSeed(32);
         streamStartBytes = new byte[32];

--- a/kdbx/src/main/java/org/linguafranca/pwdb/kdbx/StreamEncryptor.java
+++ b/kdbx/src/main/java/org/linguafranca/pwdb/kdbx/StreamEncryptor.java
@@ -16,13 +16,13 @@
 
 package org.linguafranca.pwdb.kdbx;
 
+import org.bouncycastle.crypto.StreamCipher;
+import org.bouncycastle.crypto.engines.ChaCha7539Engine;
+import org.bouncycastle.crypto.engines.Salsa20Engine;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
+import org.bouncycastle.util.encoders.Hex;
 import org.linguafranca.pwdb.security.Encryption;
-import org.spongycastle.crypto.StreamCipher;
-import org.spongycastle.crypto.engines.ChaCha7539Engine;
-import org.spongycastle.crypto.engines.Salsa20Engine;
-import org.spongycastle.crypto.params.KeyParameter;
-import org.spongycastle.crypto.params.ParametersWithIV;
-import org.spongycastle.util.encoders.Hex;
 
 import java.security.MessageDigest;
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,19 +141,17 @@
             <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
-                <version>15.0</version>
+                <version>23.0.0</version>
             </dependency>
-            <!-- for android and Java7 apparently -->
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>24.0-android</version>
+                <version>31.1-android</version>
             </dependency>
-            <!-- using spongy castle rather than bouncy castle in deference to Android -->
             <dependency>
-                <groupId>com.madgag.spongycastle</groupId>
-                <artifactId>core</artifactId>
-                <version>1.58.0.0</version>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.70</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -178,16 +176,17 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.11</version>
+                <version>1.15</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.13.2</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
+      
     </dependencyManagement>
-
     <profiles>
         <profile>
             <id>signJar</id>

--- a/simple/pom.xml
+++ b/simple/pom.xml
@@ -43,12 +43,20 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.simpleframework</groupId>
             <artifactId>simple-xml</artifactId>
             <version>2.7.1</version>
+            <exclusions>
+              <exclusion>
+        	      <!--Excluding stax because it tries to access javax.xml which is already part of JDK 17.0.3.1, not excluding it can cause errors-->
+                <groupId>stax</groupId>
+                <artifactId>stax-api</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -58,7 +66,7 @@
         <dependency>
             <groupId>com.fasterxml</groupId>
             <artifactId>aalto-xml</artifactId>
-            <version>1.0.0</version>
+            <version>1.3.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/simple/pom.xml
+++ b/simple/pom.xml
@@ -47,16 +47,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.simpleframework</groupId>
-            <artifactId>simple-xml</artifactId>
-            <version>2.7.1</version>
-            <exclusions>
-              <exclusion>
-        	      <!--Excluding stax because it tries to access javax.xml which is already part of JDK 17.0.3.1, not excluding it can cause errors-->
-                <groupId>stax</groupId>
-                <artifactId>stax-api</artifactId>
-              </exclusion>
-            </exclusions>
+  	        <groupId>com.carrotsearch.thirdparty</groupId>
+  	        <artifactId>simple-xml-safe</artifactId>
+  	        <version>2.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/simple/src/main/java/org/linguafranca/pwdb/kdbx/simple/SimpleEntry.java
+++ b/simple/src/main/java/org/linguafranca/pwdb/kdbx/simple/SimpleEntry.java
@@ -101,7 +101,7 @@ public class SimpleEntry extends AbstractEntry<SimpleDatabase, SimpleGroup, Simp
     }
 
     @Override
-    public String getProperty(String s) {
+    public char[] getProperty(String s) {
         return getStringContent(getStringProperty(s, string));
     }
 

--- a/simple/src/main/java/org/linguafranca/pwdb/kdbx/simple/model/EntryClasses.java
+++ b/simple/src/main/java/org/linguafranca/pwdb/kdbx/simple/model/EntryClasses.java
@@ -40,8 +40,8 @@ public abstract class EntryClasses {
         return null;
     }
 
-    public static String getStringContent(StringProperty property) {
-        return property == null || property.value == null? null:property.value.text;
+    public static char[] getStringContent(StringProperty property) {
+        return property == null || property.value == null? null:property.value.text.toCharArray();
     }
 
     public static BinaryProperty getBinaryProp(String name, List<BinaryProperty> binary) {
@@ -131,6 +131,9 @@ public abstract class EntryClasses {
             @Convert(KeePassBooleanConverter.class)
             // NB converters don't work on attributes -see KdbxOutputTransformer
             Boolean _protected;
+            
+            // possible security issue here?
+            // wouldn't entry password get stored in text, which is a String?
             @Text
             String text;
 


### PR DESCRIPTION
### Changes
- Updated most dependency versions.
- Added a dependency to make it compatible with Java 11. (Issue #30)
- Replaced spongycastle dependency with bouncycastle. (Issue #26)
- Replaced simple-xml dependency with simple-xml-safe. (Issue #26)
- Entry fields (url, notes, passwords) are returned as character arrays. (Issue #28)

### Notes
- My approach to solving Issue #28 is probably rather ham-fisted as it makes all Entry fields be returned as character arrays, which might not be necessary and make the library a little harder to use. 
- I did not make any changes to the JAXB/HTTP modules as I felt they weren't used enough to warrant the time and effort.
- I did not make any changes to the example or test modules.