### PR TITLE
Replace Google's guava library by Apache's commons-io.

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -18,8 +18,8 @@
             <artifactId>annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/database/src/main/java/org/linguafranca/pwdb/Group.java
+++ b/database/src/main/java/org/linguafranca/pwdb/Group.java
@@ -17,8 +17,8 @@
 package org.linguafranca.pwdb;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.UUID;
 

--- a/database/src/main/java/org/linguafranca/pwdb/security/VariantDictionary.java
+++ b/database/src/main/java/org/linguafranca/pwdb/security/VariantDictionary.java
@@ -3,14 +3,13 @@ package org.linguafranca.pwdb.security;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.linguafranca.pwdb.security.VariantDictionary.EntryType.*;
 
 /**
@@ -59,7 +58,6 @@ public class VariantDictionary {
 
 
     @SuppressWarnings("WeakerAccess")
-    @Immutable
     public static class Entry {
         private final byte type;
         private final byte @NotNull [] value;
@@ -71,7 +69,7 @@ public class VariantDictionary {
 
         public Entry(EntryType entryType, byte @NotNull [] value, ByteOrder byteOrder) {
             this.type = entryType.value;
-            this.value = checkNotNull(value, vnn);
+            this.value = requireNonNull(value, vnn);
             this.byteOrder = byteOrder;
         }
 
@@ -173,7 +171,7 @@ public class VariantDictionary {
      * @param value a buffer containing an appropriate entry
      */
     public void put(@NotNull String key, EntryType type, byte @NotNull [] value) {
-        entries.put(checkNotNull(key), new Entry(type, checkNotNull(value)));
+        entries.put(requireNonNull(key), new Entry(type, requireNonNull(value)));
     }
 
     /**
@@ -184,14 +182,14 @@ public class VariantDictionary {
         ByteBuffer bb = ByteBuffer.wrap(buf);
         bb.putLong(0, uuid.getMostSignificantBits());
         bb.putLong(8, uuid.getLeastSignificantBits());
-        entries.put(checkNotNull(key, knn), new Entry(ARRAY, buf));
+        entries.put(requireNonNull(key, knn), new Entry(ARRAY, buf));
     }
 
     /**
      * Put a byte array under the key defined
      */
     public void putByteArray(@NotNull String key, byte @NotNull [] value) {
-        entries.put(checkNotNull(key, knn), new Entry(ARRAY, value));
+        entries.put(requireNonNull(key, knn), new Entry(ARRAY, value));
     }
 
     /**
@@ -201,7 +199,7 @@ public class VariantDictionary {
         byte[] buf = new byte[8];
         ByteBuffer bb = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN);
         bb.putLong(value);
-        entries.put(checkNotNull(key, knn), new Entry(INT64, buf));
+        entries.put(requireNonNull(key, knn), new Entry(INT64, buf));
     }
     /**
      * Put a long as an unsigned64 under the key defined
@@ -210,19 +208,19 @@ public class VariantDictionary {
         byte[] buf = new byte[8];
         ByteBuffer bb = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN);
         bb.putLong(value);
-        entries.put(checkNotNull(key, knn), new Entry(UINT64, buf));
+        entries.put(requireNonNull(key, knn), new Entry(UINT64, buf));
     }
 
     public void putInt(@NotNull String key, int value) {
         byte[] buf = new byte[4];
         ByteBuffer bb = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN);
         bb.putInt(value);
-        entries.put(checkNotNull(key, knn), new Entry(INT32, buf));
+        entries.put(requireNonNull(key, knn), new Entry(INT32, buf));
     }
     public void putUInt(@NotNull String key, int value) {
         byte[] buf = new byte[4];
         ByteBuffer bb = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN);
         bb.putInt(value);
-        entries.put(checkNotNull(key, knn), new Entry(UINT32, buf));
+        entries.put(requireNonNull(key, knn), new Entry(UINT32, buf));
     }
 }

--- a/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomDatabaseWrapper.java
+++ b/dom/src/main/java/org/linguafranca/pwdb/kdbx/dom/DomDatabaseWrapper.java
@@ -35,7 +35,7 @@ import java.io.OutputStream;
 import java.util.Objects;
 import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.linguafranca.pwdb.kdbx.Helpers.base64FromUuid;
 import static org.linguafranca.pwdb.kdbx.dom.DomHelper.*;
 
@@ -81,8 +81,8 @@ public class DomDatabaseWrapper extends AbstractDatabase<DomDatabaseWrapper, Dom
     public static DomDatabaseWrapper load(@NotNull Credentials credentials,
                                           @NotNull InputStream inputStream) throws IOException {
         return new DomDatabaseWrapper(
-                checkNotNull(credentials, "Credentials must not be null"),
-                checkNotNull(inputStream, "InputStream must not be null"));
+                requireNonNull(credentials, "Credentials must not be null"),
+                requireNonNull(inputStream, "InputStream must not be null"));
     }
 
     private void init() {

--- a/example/src/main/java/org/linguafranca/pwdb/kdbx/ChooseFile.java
+++ b/example/src/main/java/org/linguafranca/pwdb/kdbx/ChooseFile.java
@@ -1,15 +1,15 @@
 package org.linguafranca.pwdb.kdbx;
 
-import com.google.common.base.Strings;
-import org.linguafranca.util.HexViewer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import static org.linguafranca.util.TestUtil.getTestPrintStream;
@@ -63,7 +63,7 @@ public class ChooseFile {
                     null,
                     null,
                     "123");
-            if (Strings.isNullOrEmpty(s)) {
+            if (s == null || s.isEmpty()) {
                 return;
             }
             logger.info("Opening {}", fc.getSelectedFile().getPath());

--- a/example/src/main/java/org/linguafranca/pwdb/kdbx/Util.java
+++ b/example/src/main/java/org/linguafranca/pwdb/kdbx/Util.java
@@ -1,6 +1,6 @@
 package org.linguafranca.pwdb.kdbx;
 
-import com.google.common.io.CharStreams;
+import org.apache.commons.io.IOUtils;
 import org.linguafranca.pwdb.Credentials;
 import org.linguafranca.pwdb.Database;
 import org.linguafranca.pwdb.StreamFormat;
@@ -8,7 +8,10 @@ import org.linguafranca.pwdb.kdbx.dom.DomDatabaseWrapper;
 import org.linguafranca.pwdb.kdbx.jaxb.JaxbDatabase;
 import org.linguafranca.pwdb.kdbx.simple.SimpleDatabase;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,7 +38,7 @@ public class Util {
     }
 
     public static String streamToString(InputStream inputStream) throws IOException {
-        return CharStreams.toString(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
     }
 
     /**

--- a/example/src/test/java/org/linguafranca/pwdb/kdbx/validation/Issue27Test.java
+++ b/example/src/test/java/org/linguafranca/pwdb/kdbx/validation/Issue27Test.java
@@ -1,6 +1,6 @@
 package org.linguafranca.pwdb.kdbx.validation;
 
-import com.google.common.io.CharStreams;
+import org.apache.commons.io.IOUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.linguafranca.pwdb.kdbx.Helpers;
@@ -60,6 +60,6 @@ public class Issue27Test {
         InputStream is = this.getClass().getClassLoader().getResourceAsStream("issue-27/bogus-timestamp2.kdbx");
         KdbxCreds creds = new KdbxCreds("passwordless".getBytes());
         InputStream plainText = KdbxSerializer.createUnencryptedInputStream(creds,new KdbxHeader(), is);
-        printStream.println(CharStreams.toString(new InputStreamReader(plainText, StandardCharsets.UTF_8)));
+        printStream.println(IOUtils.toString(new InputStreamReader(plainText, StandardCharsets.UTF_8)));
     }
 }

--- a/kdb/src/main/java/org/linguafranca/pwdb/kdb/KdbCredentials.java
+++ b/kdb/src/main/java/org/linguafranca/pwdb/kdb/KdbCredentials.java
@@ -16,10 +16,10 @@
 
 package org.linguafranca.pwdb.kdb;
 
-import com.google.common.io.ByteStreams;
+import org.apache.commons.io.IOUtils;
+import org.bouncycastle.util.encoders.Hex;
 import org.linguafranca.pwdb.Credentials;
 import org.linguafranca.pwdb.security.Encryption;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -63,7 +63,7 @@ public interface KdbCredentials extends Credentials {
             md.update(pwKey);
 
             try {
-                byte [] keyFileData = ByteStreams.toByteArray(inputStream);
+                byte [] keyFileData = IOUtils.toByteArray(inputStream);
                 if (keyFileData.length == 64) {
                     keyFileData = Hex.decode(keyFileData);
                     key = md.digest(keyFileData);

--- a/kdb/src/main/java/org/linguafranca/pwdb/kdb/KdbSerializer.java
+++ b/kdb/src/main/java/org/linguafranca/pwdb/kdb/KdbSerializer.java
@@ -16,7 +16,7 @@
 
 package org.linguafranca.pwdb.kdb;
 
-import com.google.common.io.LittleEndianDataInputStream;
+import org.apache.commons.io.input.SwappedDataInputStream;
 import org.linguafranca.pwdb.Credentials;
 import org.linguafranca.pwdb.Group;
 import org.linguafranca.pwdb.security.Encryption;
@@ -65,7 +65,7 @@ public class KdbSerializer {
      */
     public static KdbDatabase createKdbDatabase(Credentials credentials, KdbHeader kdbHeader, InputStream inputStream) throws IOException {
         // everything is little endian
-        DataInput dataInput = new LittleEndianDataInputStream(inputStream);
+        DataInput dataInput = new SwappedDataInputStream(inputStream);
         // check the magic values to verify file type
         checkSignature(dataInput);
         // load the header
@@ -79,7 +79,7 @@ public class KdbSerializer {
         DigestInputStream digestInputStream = new DigestInputStream(decryptedInputStream, digest);
 
         // Start the dataInput at wherever we have got to in the stream
-        dataInput = new LittleEndianDataInputStream(digestInputStream);
+        dataInput = new SwappedDataInputStream(digestInputStream);
 
         // read the decrypted serialized form of all groups
         KdbDatabase kdbDatabase = new KdbDatabase();

--- a/kdbx/src/main/java/org/linguafranca/pwdb/hashedblock/HmacBlockInputStream.java
+++ b/kdbx/src/main/java/org/linguafranca/pwdb/hashedblock/HmacBlockInputStream.java
@@ -1,6 +1,6 @@
 package org.linguafranca.pwdb.hashedblock;
 
-import com.google.common.io.LittleEndianDataInputStream;
+import org.apache.commons.io.input.SwappedDataInputStream;
 import org.jetbrains.annotations.NotNull;
 
 import javax.crypto.Mac;
@@ -62,7 +62,7 @@ public class HmacBlockInputStream extends FilterInputStream {
         this.byteOrder = littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
         this.key = key;
         if (littleEndian) {
-            input = new LittleEndianDataInputStream(in);
+            input = new SwappedDataInputStream(in);
         } else {
             input = new DataInputStream(in);
         }

--- a/kdbx/src/main/java/org/linguafranca/pwdb/hashedblock/HmacBlockOutputStream.java
+++ b/kdbx/src/main/java/org/linguafranca/pwdb/hashedblock/HmacBlockOutputStream.java
@@ -8,7 +8,7 @@ import java.io.*;
 import java.nio.ByteOrder;
 import javax.crypto.Mac;
 import org.jetbrains.annotations.NotNull;
-import com.google.common.io.LittleEndianDataOutputStream;
+import org.linguafranca.pwdb.util.SwappedDataOutputStream;
 
 /**
  * Takes a stream of (encrypted GZIPped) data and formats it as HMAC Hashed Blocks to the
@@ -60,8 +60,7 @@ public class HmacBlockOutputStream extends FilterOutputStream {
         this.key = key;
         this.byteOrder = littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
         if (this.byteOrder.equals(ByteOrder.LITTLE_ENDIAN)) {
-            //noinspection UnstableApiUsage
-            this.output = new LittleEndianDataOutputStream(out);
+            this.output = new SwappedDataOutputStream(out);
         } else {
             this.output = new DataOutputStream(out);
         }

--- a/kdbx/src/main/java/org/linguafranca/pwdb/kdbx/Helpers.java
+++ b/kdbx/src/main/java/org/linguafranca/pwdb/kdbx/Helpers.java
@@ -16,21 +16,21 @@
 
 package org.linguafranca.pwdb.kdbx;
 
-import com.google.common.io.ByteStreams;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.text.SimpleDateFormat;
-import java.time.*;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
-import java.util.TimeZone;
 import java.util.UUID;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -155,7 +155,7 @@ public class Helpers {
         ByteArrayInputStream bais = new ByteArrayInputStream(content);
         try {
             GZIPInputStream g = new GZIPInputStream(bais);
-            return ByteStreams.toByteArray(g);
+            return IOUtils.toByteArray(g);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/kdbx/src/main/java/org/linguafranca/pwdb/kdbx/KdbxSerializer.java
+++ b/kdbx/src/main/java/org/linguafranca/pwdb/kdbx/KdbxSerializer.java
@@ -16,12 +16,12 @@
 
 package org.linguafranca.pwdb.kdbx;
 
-import com.google.common.io.LittleEndianDataInputStream;
-import com.google.common.io.LittleEndianDataOutputStream;
+import org.apache.commons.io.input.SwappedDataInputStream;
 import org.linguafranca.pwdb.Credentials;
 import org.linguafranca.pwdb.hashedblock.*;
 import org.linguafranca.pwdb.security.Encryption;
 import org.linguafranca.pwdb.security.VariantDictionary;
+import org.linguafranca.pwdb.util.SwappedDataOutputStream;
 
 import javax.crypto.Mac;
 import java.io.*;
@@ -179,7 +179,7 @@ public class KdbxSerializer {
      * @throws IOException if the stream cannot be read, etc.
      */
     private static void checkStartBytes(KdbxHeader kdbxHeader, InputStream decryptedInputStream) throws IOException {
-        LittleEndianDataInputStream ledis = new LittleEndianDataInputStream(decryptedInputStream);
+        SwappedDataInputStream ledis = new SwappedDataInputStream(decryptedInputStream);
 
         byte [] startBytes = new byte[32];
         ledis.readFully(startBytes);
@@ -195,7 +195,7 @@ public class KdbxSerializer {
      * @throws IOException if the stream cannot be written, etc.
      */
     private static void writeStartBytes(KdbxHeader kdbxHeader, OutputStream encryptedOutputStream) throws IOException {
-        LittleEndianDataOutputStream ledos = new LittleEndianDataOutputStream(encryptedOutputStream);
+        SwappedDataOutputStream ledos = new SwappedDataOutputStream(encryptedOutputStream);
         ledos.write(kdbxHeader.getStreamStartBytes());
     }
 
@@ -236,7 +236,7 @@ public class KdbxSerializer {
         // HMac calculation depends on having collected a couple of the header fields
         CollectingInputStream collectingInputStream = new CollectingInputStream(shaDigestInputStream, true);
         // make values available from LittleEndian
-        LittleEndianDataInputStream ledis = new LittleEndianDataInputStream(collectingInputStream);
+        SwappedDataInputStream ledis = new SwappedDataInputStream(collectingInputStream);
 
         // file starts with magic number
         if (!verifyMagicNumber(ledis)) {
@@ -382,7 +382,7 @@ public class KdbxSerializer {
         MessageDigest messageDigest = Encryption.getSha256MessageDigestInstance();
         DigestOutputStream digestOutputStream = new DigestOutputStream(outputStream, messageDigest);
         CollectingOutputStream collectingOutputStream = new CollectingOutputStream(digestOutputStream);
-        LittleEndianDataOutputStream ledos = new LittleEndianDataOutputStream(collectingOutputStream);
+        SwappedDataOutputStream ledos = new SwappedDataOutputStream(collectingOutputStream);
 
         // lengths are short in v3 int in v4
         IntConsumer lengthWriter = (i -> {
@@ -483,7 +483,7 @@ public class KdbxSerializer {
      * @throws IOException on error
      */
     private static void readInnerHeader(KdbxHeader kdbxHeader, InputStream plainTextStream) throws IOException {
-        DataInput input = new LittleEndianDataInputStream(plainTextStream);
+        DataInput input = new SwappedDataInputStream(plainTextStream);
 
         byte headerType;
         do {
@@ -517,7 +517,7 @@ public class KdbxSerializer {
     }
 
     public static void writeInnerHeader(KdbxHeader kdbxHeader, OutputStream outputStream) throws IOException {
-        DataOutput output = new LittleEndianDataOutputStream(outputStream);
+        DataOutput output = new SwappedDataOutputStream(outputStream);
 
         output.writeByte(InnerHeaderType.INNER_RANDOM_STREAM_ID);
         output.writeInt(4);
@@ -602,7 +602,7 @@ public class KdbxSerializer {
      * @return true if it looks like this is a kdbx file
      * @throws IOException on error
      */
-    private static boolean verifyMagicNumber(LittleEndianDataInputStream ledis) throws IOException {
+    private static boolean verifyMagicNumber(SwappedDataInputStream ledis) throws IOException {
         int sig1 = ledis.readInt();
         int sig2 = ledis.readInt();
         return sig1 == SIG1 && sig2 == SIG2;

--- a/kdbx/src/main/java/org/linguafranca/pwdb/util/SwappedDataOutputStream.java
+++ b/kdbx/src/main/java/org/linguafranca/pwdb/util/SwappedDataOutputStream.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015 Jo Rabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.linguafranca.pwdb.util;
+
+import org.apache.commons.io.EndianUtils;
+
+import java.io.*;
+
+/**
+ * DataOutput for systems relying on little-endian data formats. When written, values will be changed from big-endian to little-endian
+ * formats for external usage.
+ */
+public final class SwappedDataOutputStream extends FilterOutputStream implements DataOutput {
+
+    /**
+     * Creates a {@code SwappedDataOutputStream} that wraps the given stream.
+     *
+     * @param out the stream to delegate to
+     */
+    public SwappedDataOutputStream(OutputStream out) {
+        super(new DataOutputStream(out));
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
+    @Override
+    public void writeBoolean(boolean v) throws IOException {
+        ((DataOutputStream) out).writeBoolean(v);
+    }
+
+    @Override
+    public void writeByte(int v) throws IOException {
+        ((DataOutputStream) out).writeByte(v);
+    }
+
+    @Deprecated
+    @Override
+    public void writeBytes(String s) throws IOException {
+        ((DataOutputStream) out).writeBytes(s);
+    }
+
+    /**
+     * Writes a char as specified by {@link DataOutputStream#writeChar(int)}, except using
+     * little-endian byte order.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeChar(int v) throws IOException {
+        writeShort(v);
+    }
+
+    /**
+     * Writes a {@code String} as specified by {@link DataOutputStream#writeChars(String)}, except
+     * each character is written using little-endian byte order.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeChars(String s) throws IOException {
+        for (int i = 0; i < s.length(); i++) {
+            writeChar(s.charAt(i));
+        }
+    }
+
+    /**
+     * Writes a {@code double} as specified by {@link DataOutputStream#writeDouble(double)}, except
+     * using little-endian byte order.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeDouble(double v) throws IOException {
+        EndianUtils.writeSwappedDouble(out, v);
+    }
+
+    /**
+     * Writes a {@code float} as specified by {@link DataOutputStream#writeFloat(float)}, except using
+     * little-endian byte order.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeFloat(float v) throws IOException {
+        EndianUtils.writeSwappedFloat(out, v);
+    }
+
+    /**
+     * Writes an {@code int} as specified by {@link DataOutputStream#writeInt(int)}, except using
+     * little-endian byte order.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeInt(int v) throws IOException {
+        EndianUtils.writeSwappedInteger(out, v);
+    }
+
+    /**
+     * Writes a {@code long} as specified by {@link DataOutputStream#writeLong(long)}, except using
+     * little-endian byte order.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeLong(long v) throws IOException {
+        EndianUtils.writeSwappedLong(out, v);
+    }
+
+    /**
+     * Writes a {@code short} as specified by {@link DataOutputStream#writeShort(int)}, except using
+     * little-endian byte order.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeShort(int v) throws IOException {
+        EndianUtils.writeSwappedShort(out, (short) v);
+    }
+
+    @Override
+    public void writeUTF(String str) throws IOException {
+        ((DataOutputStream) out).writeUTF(str);
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+}

--- a/kdbx/src/test/java/org/linguafranca/pwdb/kdbx/KdbxHeaderTest.java
+++ b/kdbx/src/test/java/org/linguafranca/pwdb/kdbx/KdbxHeaderTest.java
@@ -1,13 +1,10 @@
 package org.linguafranca.pwdb.kdbx;
 
-import com.google.common.io.CharStreams;
-import com.google.common.io.LittleEndianDataInputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.SwappedDataInputStream;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.linguafranca.pwdb.hashedblock.HmacBlockInputStream;
-import org.linguafranca.pwdb.kdbx.KdbxCreds;
-import org.linguafranca.pwdb.kdbx.KdbxHeader;
-import org.linguafranca.pwdb.kdbx.KdbxSerializer;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,10 +28,9 @@ public class KdbxHeaderTest {
         printStream.println("Version " + header.getVersion());
         KdbxCreds creds = new KdbxCreds("123".getBytes());
         assert inputStream != null;
-        //noinspection UnstableApiUsage
-        KdbxSerializer.readOuterHeaderVerification(header, creds, new LittleEndianDataInputStream(inputStream));
+        KdbxSerializer.readOuterHeaderVerification(header, creds, new SwappedDataInputStream(inputStream));
         HmacBlockInputStream hmacBlockInputStream = new HmacBlockInputStream(header.getHmacKey(creds), inputStream, true);
-        printStream.println(CharStreams.toString(new InputStreamReader(hmacBlockInputStream, StandardCharsets.UTF_8)));
+        printStream.println(IOUtils.toString(new InputStreamReader(hmacBlockInputStream, StandardCharsets.UTF_8)));
     }
 
     // check the correct version

--- a/kdbx/src/test/java/org/linguafranca/pwdb/kdbx/KdbxKeyFileTest.java
+++ b/kdbx/src/test/java/org/linguafranca/pwdb/kdbx/KdbxKeyFileTest.java
@@ -16,7 +16,7 @@
 
 package org.linguafranca.pwdb.kdbx;
 
-import com.google.common.io.CharStreams;
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.linguafranca.pwdb.Credentials;
 
@@ -38,7 +38,7 @@ public class KdbxKeyFileTest {
     static PrintStream printStream = getTestPrintStream();
 
     private static void toConsole(InputStream is) throws IOException {
-        printStream.println(CharStreams.toString(new InputStreamReader(is, StandardCharsets.UTF_8)));
+        printStream.println(IOUtils.toString(new InputStreamReader(is, StandardCharsets.UTF_8)));
     }
     /**
      * Test that we can load a key file and get a 32 byte base64 encoded value back

--- a/kdbx/src/test/java/org/linguafranca/pwdb/kdbx/KdbxSerializerTest.java
+++ b/kdbx/src/test/java/org/linguafranca/pwdb/kdbx/KdbxSerializerTest.java
@@ -16,7 +16,7 @@
 
 package org.linguafranca.pwdb.kdbx;
 
-import com.google.common.io.CharStreams;
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.linguafranca.pwdb.Credentials;
 
@@ -42,7 +42,7 @@ public class KdbxSerializerTest {
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream("Attachment.kdbx");
         Credentials credentials = new KdbxCreds("123".getBytes());
         InputStream decryptedInputStream = KdbxSerializer.createUnencryptedInputStream(credentials, new KdbxHeader(), inputStream);
-        printStream.println(CharStreams.toString(new InputStreamReader(decryptedInputStream, StandardCharsets.UTF_8)));
+        printStream.println(IOUtils.toString(new InputStreamReader(decryptedInputStream, StandardCharsets.UTF_8)));
     }
 
     /**
@@ -53,7 +53,7 @@ public class KdbxSerializerTest {
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream("V4-ChaCha20-AES.kdbx");
         Credentials credentials = new KdbxCreds("123".getBytes());
         InputStream decryptedInputStream = KdbxSerializer.createUnencryptedInputStream(credentials, new KdbxHeader(), inputStream);
-        printStream.println(CharStreams.toString(new InputStreamReader(decryptedInputStream, StandardCharsets.UTF_8)));
+        printStream.println(IOUtils.toString(new InputStreamReader(decryptedInputStream, StandardCharsets.UTF_8)));
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -173,12 +173,6 @@
                 <artifactId>annotations</artifactId>
                 <version>24.0.1</version>
             </dependency>
-            <!-- for android and Java7 apparently -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>32.1.2-android</version>
-            </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
@@ -195,6 +189,11 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>1.3.7</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.16.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ KeePass formats in the following locations:
 
 Aside from the JRE, at release 2.2, the API depends on:
 
-- [Google Guava](https://github.com/google/guava/wiki) ([Apache 2 license](https://github.com/google/guava/blob/master/COPYING)).
+- [Apache Commons IO](https://commons.apache.org/proper/commons-io/) ([Apache 2 license](http://www.apache.org/licenses/LICENSE-2.0)).
 - [Apache Commons Codec](https://commons.apache.org/proper/commons-codec/) ([Apache 2 license](http://www.apache.org/licenses/LICENSE-2.0)).
 - [Bouncy Castle](https://github.com/bcgit/bc-java/blob/master/LICENSE.html) ([MIT License](https://github.com/bcgit/bc-java/blob/master/LICENSE.html)).
 

--- a/test/src/main/java/org/linguafranca/pwdb/checks/BinaryPropertyChecks.java
+++ b/test/src/main/java/org/linguafranca/pwdb/checks/BinaryPropertyChecks.java
@@ -16,7 +16,7 @@
 
 package org.linguafranca.pwdb.checks;
 
-import com.google.common.io.ByteStreams;
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.linguafranca.pwdb.*;
@@ -67,7 +67,7 @@ public abstract class BinaryPropertyChecks  <D extends Database<D,G,E,I>, G exte
         byte [] letterJ = entry.getBinaryProperty("letter J.jpeg");
         InputStream testFile = getClass().getClassLoader().getResourceAsStream("letter J.jpeg");
         assert testFile != null;
-        byte [] original = ByteStreams.toByteArray(testFile);
+        byte [] original = IOUtils.toByteArray(testFile);
         Assert.assertArrayEquals(original, letterJ);
     }
 
@@ -80,7 +80,7 @@ public abstract class BinaryPropertyChecks  <D extends Database<D,G,E,I>, G exte
         byte [] letterL = entry.getBinaryProperty("letter L.jpeg");
         InputStream testFile = getClass().getClassLoader().getResourceAsStream("letter L.jpeg");
         assert testFile != null;
-        byte [] original = ByteStreams.toByteArray(testFile);
+        byte [] original = IOUtils.toByteArray(testFile);
         Assert.assertArrayEquals(original, letterL);
     }
 
@@ -91,7 +91,7 @@ public abstract class BinaryPropertyChecks  <D extends Database<D,G,E,I>, G exte
     public void setBinaryProperty() throws Exception {
         InputStream testFile = getClass().getClassLoader().getResourceAsStream("letter L.jpeg");
         assert testFile != null;
-        byte [] original = ByteStreams.toByteArray(testFile);
+        byte [] original = IOUtils.toByteArray(testFile);
         E entry = database.findEntries("Test attachment").get(0);
         entry.setBinaryProperty("letter L.jpeg", original);
         byte [] letterL = entry.getBinaryProperty("letter L.jpeg");
@@ -177,7 +177,7 @@ public abstract class BinaryPropertyChecks  <D extends Database<D,G,E,I>, G exte
         database1.getRootGroup().addEntry(entry);
         InputStream testFile = getClass().getClassLoader().getResourceAsStream("letter J.jpeg");
         assert testFile != null;
-        byte [] letterJ = ByteStreams.toByteArray(testFile);
+        byte [] letterJ = IOUtils.toByteArray(testFile);
         entry.setBinaryProperty("letter J.jpeg", letterJ);
         saveDatabase(database1, getCreds("123".getBytes()), Files.newOutputStream(file));
 

--- a/test/src/main/java/org/linguafranca/util/TestUtil.java
+++ b/test/src/main/java/org/linguafranca/util/TestUtil.java
@@ -1,6 +1,6 @@
 package org.linguafranca.util;
 
-import com.google.common.io.ByteStreams;
+import org.apache.commons.io.output.NullOutputStream;
 
 import java.io.PrintStream;
 
@@ -11,7 +11,7 @@ public class TestUtil {
      */
     public static PrintStream getTestPrintStream() {
         return Boolean.getBoolean("inhibitConsoleOutput") ?
-                new PrintStream(ByteStreams.nullOutputStream()) :
+                new PrintStream(NullOutputStream.INSTANCE) :
                 new PrintStream(System.out);
     }
 }


### PR DESCRIPTION
This PR remove guava library and replace it by commons-io.

Reasons are : 
 - commons-io is a smaller library (574kb compared to 2.8Mb for guava)
 - guava duplicates a lot of features found in commonly used frameworks (like Spring)

Thank in advance !