### PR TITLE
Updates util package to test scope only

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -25,6 +25,7 @@
             <groupId>org.linguafranca.pwdb</groupId>
             <artifactId>util</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/dom/pom.xml
+++ b/dom/pom.xml
@@ -19,6 +19,12 @@
         </dependency>
         <dependency>
             <groupId>org.linguafranca.pwdb</groupId>
+            <artifactId>util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.linguafranca.pwdb</groupId>
             <artifactId>test</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
         <dependency>
             <groupId>org.linguafranca.pwdb</groupId>
+            <artifactId>util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.linguafranca.pwdb</groupId>
             <artifactId>test</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -35,6 +35,12 @@
     </dependency>
     <dependency>
       <groupId>org.linguafranca.pwdb</groupId>
+      <artifactId>util</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.linguafranca.pwdb</groupId>
       <artifactId>test</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
         <dependency>
             <groupId>org.linguafranca.pwdb</groupId>
+            <artifactId>util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.linguafranca.pwdb</groupId>
             <artifactId>test</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/kdb/pom.xml
+++ b/kdb/pom.xml
@@ -20,6 +20,12 @@
         </dependency>
         <dependency>
             <groupId>org.linguafranca.pwdb</groupId>
+            <artifactId>util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.linguafranca.pwdb</groupId>
             <artifactId>test</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/kdbx/pom.xml
+++ b/kdbx/pom.xml
@@ -45,6 +45,12 @@
 		</dependency>
         <dependency>
             <groupId>org.linguafranca.pwdb</groupId>
+            <artifactId>util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.linguafranca.pwdb</groupId>
             <artifactId>test</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/simple/pom.xml
+++ b/simple/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
         <dependency>
             <groupId>org.linguafranca.pwdb</groupId>
+            <artifactId>util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.linguafranca.pwdb</groupId>
             <artifactId>test</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>


### PR DESCRIPTION
Currently, the util dependency is attached to all of the published jars, this change sets the scope of the dependency to test only but we do have to add the dependency to each of the modules that require it.

Suggestion: Perhaps the `test` and `util` modules can be merged into one. 

Let me know of your thoughts.
