### PR TITLE
Updating bcpkix-jdk18on to resolve vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
-                <version>1.78.1</version>
+                <version>1.83</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This pull request updates a dependency version in the `pom.xml` file to keep the project up to date with the latest security and feature improvements.

Dependency updates:

* Upgraded the `bcpkix-jdk18on` dependency from version `1.78.1` to `1.83` in `pom.xml`. Resolves [CVE-2025-8916](https://www.cve.org/CVERecord?id=CVE-2025-8916)